### PR TITLE
Improve timeline

### DIFF
--- a/src/Timeline.h
+++ b/src/Timeline.h
@@ -174,6 +174,10 @@ private slots:
     void goToPreviousFrame(View * view);
     void goToNextFrame(View * view);
     void goToLastFrame(View * view);
+    void checkPlayingWindow();
+    void clampFrame();
+    void clampFrame(double frame);
+    void clampFrame(View * view, double frame);
     void goToFrame(View * view, int frame);
     void goToFrame(View * view, double frame);
 


### PR DESCRIPTION
This pull request fixes two timeline related issues:

1. Current frames going outside boundaries. There were some situations where you could set the current frame to a time that is less than the start time or greater than the end time. For example, left click dragging on the timeline or the view settings controls would exhibit this behavior. With this update there *should* be no way to edit a frame beyond the boundaries of the a field.
2. Invalid start and end times. You were allowed to set start times that were later than the end times (or end times that were earlier than start times if you prefer to look at it that way). This behavior has been changed so that the start time is always before the end time and there is always at least one selectable frame.