### PR TITLE
use qmake's c++11 compiler switch macro in .pro

### DIFF
--- a/src/VPaint.pro
+++ b/src/VPaint.pro
@@ -19,7 +19,7 @@ macx: ICON = images/vpaint.icns
 # Compiler flags for Linux
 unix:!macx {
   # Use C++11
-  QMAKE_CXXFLAGS += -std=c++11
+  QMAKE_CXXFLAGS += $${QMAKE_CXXFLAGS_CXX11}
   # Link to GLU
   LIBS += -lGLU
   # Use dwarf debug dymbols
@@ -31,7 +31,7 @@ unix:!macx {
 # Compiler flags for Mac OS X
 macx {
   # Use C++11
-  QMAKE_CXXFLAGS += -std=c++11
+  QMAKE_CXXFLAGS += $${QMAKE_CXXFLAGS_CXX11}
 }
 
 # Compiler flags for Windows


### PR DESCRIPTION
rather than explicitly say -std=c++11.

grepping qt's mkspecs/ directory, i see clang has the macro set to
-std=c++11 and gcc has it set to -std=c++0x. i guess that's because qt
distributes with a mkspec for gcc42, not gcc48. maybe we can overwrite
that, or explain in the readme how to overwrite that when setting up the
project and creating a copy of the mkspec for gcc48.