### PR TITLE
Fixed mac delete key

### DIFF
--- a/src/Global.cpp
+++ b/src/Global.cpp
@@ -119,6 +119,14 @@ bool Global::eventFilter(QObject * /*watched*/, QEvent * event)
         QKeyEvent * keyEvent = static_cast<QKeyEvent *>(event);
         if(keyEvent)
         {
+            // Workaround for Mac delete key
+            // This is needed because of a bug in QT 5 that has not been resolved as of 5.5.0
+#ifdef Q_OS_MAC
+            if(keyEvent->key() == Qt::Key_Backspace)
+            {
+                scene()->smartDelete();
+            }
+#endif
             if(keyEvent->key() == Qt::Key_Shift ||
                keyEvent->key() == Qt::Key_Alt ||
                keyEvent->key() == Qt::Key_Meta ||


### PR DESCRIPTION
Fixed issue with delete key not working on mac as discussed [here](vpaint.org/forum/viewtopic.php?f=3&t=59). This is not a permanent solution, it's just a workaround until the qt developers fix this issue permanently.