### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/VectorAnimationComplex/Cycle.cpp
+++ b/src/VectorAnimationComplex/Cycle.cpp
@@ -525,8 +525,6 @@ double Cycle::totalCurvature() const
     }
 }
 
-#define M_PI 3.14159265358979323846  /* pi */
-
 int Cycle::turningNumber() const
 {
     // Note: std::round is C++11, not supported by Visual Studio 2012

--- a/src/VectorAnimationComplex/EdgeGeometry.cpp
+++ b/src/VectorAnimationComplex/EdgeGeometry.cpp
@@ -14,7 +14,6 @@
 #include "../SaveAndLoad.h"
 #include "../OpenGL.h"
 #include <cmath>
-#define M_PI 3.14159265358979323846  /* pi */
 #include "../DevSettings.h"
 #include <QtDebug>
 

--- a/src/ViewSettings.cpp
+++ b/src/ViewSettings.cpp
@@ -311,8 +311,6 @@ ViewSettingsWidget::ViewSettingsWidget(ViewSettings & viewSettings, QWidget * pa
     //frameZoomLayout->setMargin(0);
     //frameZoomLayout->setSpacing(0);
 
-    int frameZoomWidth = buttonSize+30;
-
     QPushButton * goToPreviousFrameButton = new QPushButton();
     goToPreviousFrameButton->setFixedSize(20,20);
     goToPreviousFrameButton->setIcon(QIcon(":/images/go-first-view.png"));

--- a/src/ViewSettings.cpp
+++ b/src/ViewSettings.cpp
@@ -958,16 +958,15 @@ void ViewSettingsWidget::updateWidgetFromSettings()
         break;
     }
 
-    switch(viewSettings_.onionSkinningIsEnabled())
+    if(viewSettings_.onionSkinningIsEnabled())
     {
-    case false:
-        onionSkinningButton_Off_->setChecked(true);
-        onionSkinningButton_->setIcon(QIcon(":images/onion-skinning-off.png"));
-        break;
-    case true:
         onionSkinningButton_On_->setChecked(true);
         onionSkinningButton_->setIcon(QIcon(":images/onion-skinning-on.png"));
-        break;
+    }
+    else
+    {
+        onionSkinningButton_Off_->setChecked(true);
+        onionSkinningButton_->setIcon(QIcon(":images/onion-skinning-off.png"));
     }
 }
 


### PR DESCRIPTION
These commits fix 4 warnings:

 * 2 warnings on redefinition of macro `M_PI` defined in standard C header math.h.
 * warning on unused variable
 * warning on boolean expression in switch condition. 