### PR TITLE
Fixed windows icon setting in Gui.pro

### DIFF
--- a/src/Gui/Gui.pro
+++ b/src/Gui/Gui.pro
@@ -17,7 +17,7 @@ VERSION = 1.5
 DEFINES += APP_VERSION=\\\"$$VERSION\\\"
 
 # To create the icon on Windows
-win32: RC_FILE = VPaint.rc
+win32: RC_ICONS += images/VPaint.ico
 
 # To create the icon on MacOS X
 macx: ICON = images/vpaint.icns


### PR DESCRIPTION
Based off of [this documentation](http://doc.qt.io/qt-5/appicon.html), I switched the RC_FILE used by qt 4 for the RC_ICONS used by qt 5. This should work, but it is untested.

Fixes #44 