### PR TITLE
Fixed mac tooltip bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,9 @@ innovative techniques.
 
 ## Mac OS X
 
-- On Mac OS X 10.10 Yosemite, maximizing the window is poorly supported. If you want to exit maximizing, hide the toolbar and action bar with "View > Toolbar" and "View > Action Bar" so you can access the minimize button again.
+- On Mac OS X 10.10 Yosemite and above, maximizing the window is poorly supported. If you want to exit maximizing, hide the toolbar and action bar with "View > Toolbar" and "View > Action Bar" so you can access the minimize button again.
 
 - If you have a retina display, then the pointer drawn by VPaint is not at the same location as your mouse cursor. It doesn't prevent using VPaint but it is quite inconvenient. See [#22](https://github.com/dalboris/vpaint/issues/22) for details.
-
-- In the status bar (at the bottom), whenever "CTRL" is mentioned, you should use the COMMAND key instead. 
-
 
 #  LICENSE
 

--- a/src/Gui/Global.cpp
+++ b/src/Gui/Global.cpp
@@ -650,7 +650,7 @@ void Global::updateStatusBarHelp()
         message += "[";
         if(isCtrlDown)
         {
-            message += "CTRL";
+            message += QString(ACTION_MODIFIER_NAME_SHORT).toUpper();
             if(isShiftDown || isAltDown)
                 message += ",";
         }
@@ -671,7 +671,7 @@ void Global::updateStatusBarHelp()
     if(toolMode() == SELECT)
     {
         if(!isCtrlDown && !isShiftDown && !isAltDown) {
-            message += "Click to select highlighted object. Click on background to deselect all. Hold CTRL, SHIFT, or ALT for more actions.";
+            message += "Click to select highlighted object. Click on background to deselect all. Hold " + QString(ACTION_MODIFIER_NAME_SHORT).toUpper() + ", SHIFT, or ALT for more actions.";
         }
         else if(isCtrlDown && !isShiftDown && !isAltDown) {
             message += "Click on curve to insert end point. Click on face to insert point-in-face.";
@@ -692,7 +692,7 @@ void Global::updateStatusBarHelp()
     else if(toolMode() == SKETCH)
     {
         if(!isCtrlDown && !isShiftDown && !isAltDown) {
-            message += "Hold left mouse button to draw a curve. CTRL: Change pen width. ALT: Change snap threshold.";
+            message += "Hold left mouse button to draw a curve. " + QString(ACTION_MODIFIER_NAME_SHORT).toUpper() + ": Change pen width. ALT: Change snap threshold.";
         }
         else if(isCtrlDown && !isShiftDown && !isAltDown) {
             message += "Hold left mouse button to change pen width.";
@@ -719,7 +719,7 @@ void Global::updateStatusBarHelp()
     else if(toolMode() == SCULPT)
     {
         if(!isCtrlDown && !isShiftDown && !isAltDown) {
-            message += "Hold left mouse button (LMB) to drag endpoint, or drag curve within radius. CTRL: radius. SHIFT: smooth. ALT: thickness.";
+            message += "Hold left mouse button (LMB) to drag endpoint, or drag curve within radius. " + QString(ACTION_MODIFIER_NAME_SHORT).toUpper() + ": radius. SHIFT: smooth. ALT: thickness.";
         }
         else if(isCtrlDown && !isShiftDown && !isAltDown) {
             message += "Hold LMB to change the radius of the sculpting tool. Note: radius not visible if cursor too far from curve.";

--- a/src/Gui/Gui.pro
+++ b/src/Gui/Gui.pro
@@ -43,6 +43,13 @@ macx {
   FILE_ICONS.files = images/vec.icns
   FILE_ICONS.path = Contents/Resources
   QMAKE_BUNDLE_DATA += FILE_ICONS
+
+  # Names for control/command modifier key
+  DEFINES += ACTION_MODIFIER_NAME_SHORT=\\\"Cmd\\\" ACTION_MODIFIER_NAME=\\\"Command\\\"
+}
+else {
+  # Names for control/command modifier key
+  DEFINES += ACTION_MODIFIER_NAME_SHORT=\\\"Ctrl\\\" ACTION_MODIFIER_NAME=\\\"Control\\\"
 }
 
 # Compiler flags for Windows


### PR DESCRIPTION
Sorry, I would've liked to be a little more active the past few months. I was having so many difficulties with my development environment unfortunately. Finally I've got things fixed up and VPaint is compiling again. This is just a quick fix for the tooltip on mac displaying the incorrect modifier key name. Hopefully I'll get started on some other things for this project soon :wink:

I should probably ask these questions. v1.6 was slated for October, then bumped to January. Will it be bumped again? Is this a project you plan on continuing to develop?