### PR TITLE
Changes for 1.6

### DIFF
--- a/src/Gui/UpdateCheck.cpp
+++ b/src/Gui/UpdateCheck.cpp
@@ -22,6 +22,10 @@ UpdateCheck::UpdateCheck(QWidget * parent) :
 {
     // Initialize variables
     versionToCheck_ = global()->settings().checkVersion();
+    if(versionToCheck_ < Version(qApp->applicationVersion()) && versionToCheck_ != Version()) {
+        global()->settings().setCheckVersion(Version(qApp->applicationVersion()));
+        versionToCheck_ = global()->settings().checkVersion();
+    }
     networkManager_ = new QNetworkAccessManager();
     parent_ = parent;
 
@@ -97,6 +101,7 @@ void UpdateCheck::requestFinished_()
     // Compare versions
     if(versionToCheck_ < latestVersion_)
     {
+        qDebug() << versionToCheck_.toString() << " - " << latestVersion_.toString();
         // Create dialog with latest version
         dialog_ = new UpdateCheckDialog(latestVersion_.toString(), parent_, Qt::Dialog);
         dialog_->setAttribute(Qt::WA_DeleteOnClose);

--- a/src/Gui/VectorAnimationComplex/BoundingBox.cpp
+++ b/src/Gui/VectorAnimationComplex/BoundingBox.cpp
@@ -23,7 +23,7 @@ inline bool isnan_(double x)
 #ifdef WIN32
     return x != x;
 #else
-    return std::isnan(res);
+    return std::isnan(x);
 #endif
 }
 


### PR DESCRIPTION
So much for not making another PR :blush:

I thought I would test things out on my system before you officially make a 1.6 release to make sure everything works for me. Scaling, rotating, and a save prompt on exit all work perfectly. There was a very minor compilation error which I have fixed.

I also spotted a pretty stupid error with the update checker. Basically because the config version number was being used and not updated, whenever someone actually updated VPaint, the messages would continue to display. That is fixed now as well.

I was experimenting with the displaying background images, and I decided to implement a quick new option for it: repeat. As you may guess, it just repeats the image sequence. It does not affect missing frames within the frame range. As I've commented in the code, there's probably a better way to do the looping before the minFrame_ (lines 305 and 340 in Background.cpp), but I'm not all that good with modulus arithmetic so I'll leave that to you to see if it can be improved.

Also I have a quick question that I came up with while writing this description. Are the paths for background images handled in a cross-platform way? I don't really have any easy way to test this myself, but I just imagine that it could be an issue since a relative path on linux would be `folder/example.png` and the same path on windows would be `folder\example.png`.