### PR TITLE
Added repeat option for background image sequences

### DIFF
--- a/src/Gui/Background/Background.cpp
+++ b/src/Gui/Background/Background.cpp
@@ -588,6 +588,9 @@ void Background::write(XmlStreamWriter & xml)
 
     // Hold
     xml.writeAttribute("hold", hold() ? "yes" : "no");
+
+    // Sequence Repeat
+    xml.writeAttribute("sequencerepeat", repeat() ? "normal" : "none");
 }
 
 void Background::read(XmlStreamReader & xml)
@@ -670,6 +673,20 @@ void Background::read(XmlStreamReader & xml)
         else if (holdString == "no")
         {
             data.hold = false;
+        }
+    }
+
+    // Repeat sequence
+    if(xml.attributes().hasAttribute("sequencerepeat"))
+    {
+        QString repeatString =  xml.attributes().value("sequencerepeat").toString();
+        if (repeatString == "none")
+        {
+            data.repeat = false;
+        }
+        else
+        {
+            data.repeat = true;
         }
     }
 

--- a/src/Gui/Background/Background.cpp
+++ b/src/Gui/Background/Background.cpp
@@ -301,7 +301,9 @@ int Background::referenceFrame(int frame) const
     {
         if (frame < minFrame_)
         {
-            if (hold())
+            if (repeat())
+                return referenceFrames_[(referenceFrames_.size() - (referenceFrames_.size() - (frame - minFrame_)) % referenceFrames_.size()) % referenceFrames_.size()]; // There's got to be a better way to do this
+            else if (hold())
                 return referenceFrames_.first();
             else
                 return minFrame_ - 1;
@@ -312,6 +314,8 @@ int Background::referenceFrame(int frame) const
         }
         else
         {
+            if (repeat())
+                return referenceFrames_[(frame - minFrame_) % referenceFrames_.size()];
             if (hold())
                 return referenceFrames_.last();
             else
@@ -332,7 +336,9 @@ QString Background::resolvedImageFilePath(int frame) const
     {
         if (frame < minFrame_)
         {
-            if (hold())
+            if (repeat())
+                return filePathsWildcards_[(filePathsWildcards_.size() - (filePathsWildcards_.size() - (frame - minFrame_)) % filePathsWildcards_.size()) % filePathsWildcards_.size()]; // There's got to be a better way to do this
+            else if (hold())
                 filePath += filePathsWildcards_.first();
         }
         else if (frame < minFrame_ + filePathsWildcards_.size())
@@ -341,7 +347,9 @@ QString Background::resolvedImageFilePath(int frame) const
         }
         else
         {
-            if (hold())
+            if (repeat())
+                filePath += filePathsWildcards_[(frame - minFrame_) % filePathsWildcards_.size()];
+            else if (hold())
                 filePath += filePathsWildcards_.last();
         }
     }
@@ -502,6 +510,23 @@ void Background::setHold(bool newHold)
         data_.hold = newHold;
         clearCache_();
         emit holdChanged(data_.hold);
+        emit changed();
+    }
+}
+
+// Repeat
+bool Background::repeat() const
+{
+    return data_.repeat;
+}
+
+void Background::setRepeat(bool newRepeat)
+{
+    if (data_.repeat != newRepeat)
+    {
+        data_.repeat = newRepeat;
+        clearCache_();
+        emit repeatChanged(data_.repeat);
         emit changed();
     }
 }

--- a/src/Gui/Background/Background.h
+++ b/src/Gui/Background/Background.h
@@ -105,6 +105,10 @@ public:
     bool hold() const;
     void setHold(bool newHold);
 
+    // Repeat
+    bool repeat() const;
+    void setRepeat(bool newRepeat);
+
     // Cache
     void clearCache();
 
@@ -151,6 +155,7 @@ signals:
     void repeatTypeChanged(RepeatType newRepeatType);
     void opacityChanged(double newOpacity);
     void holdChanged(bool newHold);
+    void repeatChanged(bool newRepeat);
 
     // Signal emitted when the cache is cleared.
     // Clients performing further caching of images should listen to this

--- a/src/Gui/Background/BackgroundData.cpp
+++ b/src/Gui/Background/BackgroundData.cpp
@@ -16,7 +16,8 @@ BackgroundData::BackgroundData() :
     size(1280.0, 720.0),
     repeatType(RepeatType::NoRepeat),
     opacity(1.0),
-    hold(true)
+    hold(true),
+    repeat(true)
 {
 }
 
@@ -29,7 +30,8 @@ bool BackgroundData::operator==(const BackgroundData & other) const
            (size == other.size) &&
            (repeatType == other.repeatType) &&
            (opacity == other.opacity) &&
-           (hold == other.hold);
+           (hold == other.hold) &&
+           (repeat == other.repeat);
 }
 
 bool BackgroundData::operator!=(const BackgroundData & other) const

--- a/src/Gui/Background/BackgroundData.h
+++ b/src/Gui/Background/BackgroundData.h
@@ -40,6 +40,7 @@ struct BackgroundData
     RepeatType repeatType;
     double opacity;
     bool hold;
+    bool repeat;
 
     // Default background data values
     BackgroundData();

--- a/src/Gui/Background/BackgroundWidget.cpp
+++ b/src/Gui/Background/BackgroundWidget.cpp
@@ -172,6 +172,10 @@ BackgroundWidget::BackgroundWidget(QWidget * parent) :
     connect(opacitySpinBox_, SIGNAL(editingFinished()),
             this, SLOT(processOpacitySpinBoxEditingFinished_()));
 
+    // Sequence Label
+    QLabel * sequenceLabel = new QLabel("Sequence Options");
+    layout->addRow(sequenceLabel);
+
     // Hold
     holdCheckBox_ = new QCheckBox();
     holdCheckBox_->setToolTip(tr("Hold background image(s)"));
@@ -180,10 +184,22 @@ BackgroundWidget::BackgroundWidget(QWidget * parent) :
                                    "frame 2, if hold is checked, 'image01.png' appears. If hold is "
                                    "not checked, no image appears, unless 'image.png' exists in which "
                                    "case it is used as a fallback value."));
-    holdCheckBox_->setChecked(true );
+    holdCheckBox_->setChecked(true);
     layout->addRow(tr("Hold:"), holdCheckBox_);
     connect(holdCheckBox_, SIGNAL(toggled(bool)),
             this, SLOT(processHoldCheckBoxToggled_(bool)));
+
+    // Repeat
+    repeatCheckBox_ = new QCheckBox();
+    repeatCheckBox_->setToolTip(tr("Repeat background image(s)"));
+    repeatCheckBox_->setStatusTip(tr("Set whether to repeat background image(s). Example: 'image*.png'"
+                                   " with only 'image01.png' to 'image03.png' inclusive on disk. At "
+                                   "frame 4, if repeat is checked, 'image01.png' appears. If repeat is "
+                                   "not checked, the image displayed depends on the value of hold."));
+    repeatCheckBox_->setChecked(true);
+    layout->addRow(tr("Repeat:"), repeatCheckBox_);
+    connect(repeatCheckBox_, SIGNAL(toggled(bool)),
+            this, SLOT(processRepeatCheckBoxToggled_(bool)));
 
     // Set no background
     setBackground(0);
@@ -257,6 +273,9 @@ void BackgroundWidget::updateFromBackground_()
 
         // Hold
         holdCheckBox_->setChecked(background_->hold());
+
+        // Repeat
+        repeatCheckBox_->setChecked(background_->repeat());
 
         // Cache value before editing
         if (!isBeingEdited_)
@@ -625,6 +644,17 @@ void BackgroundWidget::processHoldCheckBoxToggled_(bool newHold)
     {
         isBeingEdited_ = true;
         background_->setHold(newHold);
+        isBeingEdited_ = false;
+        emitCheckpoint_();
+    }
+}
+
+void BackgroundWidget::processRepeatCheckBoxToggled_(bool newRepeat)
+{
+    if (background_ && !isUpdatingFromBackground_)
+    {
+        isBeingEdited_ = true;
+        background_->setRepeat(newRepeat);
         isBeingEdited_ = false;
         emitCheckpoint_();
     }

--- a/src/Gui/Background/BackgroundWidget.h
+++ b/src/Gui/Background/BackgroundWidget.h
@@ -77,6 +77,8 @@ private slots:
     void processOpacitySpinBoxEditingFinished_();
     // Hold
     void processHoldCheckBoxToggled_(bool newHold);
+    // Repeat
+    void processRepeatCheckBoxToggled_(bool newRepeat);
 
 private:
     // Background operated by BackgroundWidget
@@ -102,6 +104,8 @@ private:
     QDoubleSpinBox * opacitySpinBox_;
     // Hold
     QCheckBox * holdCheckBox_;
+    // Repeat
+    QCheckBox * repeatCheckBox_;
 
     // Guard needed for updateFromBackground_()
     // It is needed is to avoid modifying back 'this->background_' when


### PR DESCRIPTION
Allows for the looping of background image sequences.

Setting is stored as a string because different types of looping may be implemented in the future (for example bounce like the playback loop type).