### PR TITLE
Fix building on recent linux/gcc

### DIFF
--- a/src/Gui/Gui.pro
+++ b/src/Gui/Gui.pro
@@ -90,7 +90,7 @@ win32 {
 # Add shipped external libraries to includepath and dependpath
 INCLUDEPATH += $$PWD/../Third/
 DEPENDPATH += $$PWD/../Third/
-!win32: QMAKE_CXXFLAGS += $$QMAKE_CFLAGS_ISYSTEM $$PWD/../Third/
+!win32: QMAKE_CXXFLAGS += $$QMAKE_CFLAGS_ISYSTEM
 
 # Define RELEASE_OR_DEBUG convenient variable
 CONFIG(release, debug|release): RELEASE_OR_DEBUG = release


### PR DESCRIPTION
Salut Boris!

First and foremost I know you're busy with VGC Illustration, so if evaluating this should cost you more than 15 minutes or so of your precious time, please feel free to entirely postpone looking at this PR to quieter days ;) (I'm excited for the upcoming alphas :+1: fingers crossed for making good progress!).

That said:
I received a comment on the [Arch/AUR package for VPaint](https://aur.archlinux.org/packages/vpaint) (which I still maintain) reporting that building is currently broken, and sure enough me and another person could confirm it (recent Manjaro in at least two cases).

The problem occurs in this build step (nevermind everything but the third argument - `/home/simon/vpaint/src/Gui/../Third/` - of this g++ call):

```
g++ -Wl,-O1 -pipe /home/simon/vpaint/src/Gui/../Third/ -O2 -std=gnu++11 -flto=4 -fno-fat-lto-objects -fuse-linker-plugin -fPIC -o VPaint main.o SaveAndLoad.o Picking.o Random.o GLUtils.o GLWidget.o MainWindow.o GeometryUtils.o SceneObject.o SceneObjectVisitor.o KeyFrame.o Scene.o MultiView.o View.o View3D.o Timeline.o Global.o ColorSelector.o SpinBox.o Intersection.o Cell.o KeyCell.o KeyFace.o KeyEdge.o Halfedge.o FaceCell.o EdgeCell.o VertexCell.o KeyVertex.o EdgeGeometry.o CellVisitor.o Operators.o Operator.o ProperCycle.o ProperPath.o CycleHelper.o ZOrderedCells.o EdgeSample.o Cycle.o Algorithms.o SmartKeyEdgeSet.o Triangles.o SelectionInfoWidget.o Path.o AnimatedVertex.o AnimatedCycle.o CellLinkedList.o HalfedgeBase.o KeyHalfedge.o ViewSettings.o View3DSettings.o ObjectPropertiesWidget.o AnimatedCycleWidget.o CellObserver.o Color.o DevSettings.o Settings.o SettingsDialog.o InbetweenCell.o InbetweenEdge.o InbetweenFace.o InbetweenHalfedge.o InbetweenVertex.o VAC.o XmlStreamWriter.o XmlStreamReader.o CssColor.o TimeDef.o EditCanvasSizeDialog.o ExportPngDialog.o AboutDialog.o ViewWidget.o Background.o BackgroundData.o BackgroundRenderer.o BackgroundWidget.o BackgroundUrlValidator.o FileVersionConverter.o XmlStreamTraverser.o XmlStreamConverter.o XmlStreamConverter_1_0_to_1_6.o FileVersionConverterDialog.o Version.o BoundingBox.o TransformTool.o LayersWidget.o Layer.o SvgParser.o SvgImportDialog.o SvgImportParams.o Application.o UpdateCheckDialog.o UpdateCheck.o qrc_resources.o moc_MainWindow.o moc_GLWidget.o moc_SceneObject.o moc_Scene.o moc_MultiView.o moc_View.o moc_View3D.o moc_Timeline.o moc_Global.o moc_ColorSelector.o moc_SpinBox.o moc_SelectionInfoWidget.o moc_ViewSettings.o moc_View3DSettings.o moc_ObjectPropertiesWidget.o moc_AnimatedCycleWidget.o moc_DevSettings.o moc_SettingsDialog.o moc_VAC.o moc_EditCanvasSizeDialog.o moc_ExportPngDialog.o moc_AboutDialog.o moc_ViewWidget.o moc_Background.o moc_BackgroundRenderer.o moc_BackgroundWidget.o moc_FileVersionConverterDialog.o moc_TransformTool.o moc_LayersWidget.o moc_Layer.o moc_SvgImportDialog.o moc_Application.o moc_UpdateCheckDialog.o moc_UpdateCheck.o   -lGLU -L/home/simon/vpaint/build/Gui/../Third/GLEW/ -lGLEW /usr/lib/libQt5OpenGL.so /usr/lib/libQt5Widgets.so /usr/lib/libQt5OpenGLExtensions.a /usr/lib/libQt5Gui.so /usr/lib/libQt5Network.so /usr/lib/libQt5Core.so -lGL -lpthread
```
... triggering the following error:

```
/usr/bin/ld: error: /home/simon/vpaint/src/Gui/../Third/: read: Is a directory
```

I tracked the insertion of this parameter down to the `Gui.pro` file, where it is inserted as `$$PWD/../Third/`, and this has been there since 2015 (or even earlier, the file even had two different names inbetween) according to my research in the git history. Removing it fixes the build issue, turning the formerly problematic g++ call into this (basically just the third argument gone):

```
g++ -Wl,-O1 -pipe -O2 -std=gnu++11 -flto=4 -fno-fat-lto-objects -fuse-linker-plugin -fPIC -o VPaint main.o SaveAndLoad.o Picking.o Random.o GLUtils.o GLWidget.o MainWindow.o GeometryUtils.o SceneObject.o SceneObjectVisitor.o KeyFrame.o Scene.o MultiView.o View.o View3D.o Timeline.o Global.o ColorSelector.o SpinBox.o Intersection.o Cell.o KeyCell.o KeyFace.o KeyEdge.o Halfedge.o FaceCell.o EdgeCell.o VertexCell.o KeyVertex.o EdgeGeometry.o CellVisitor.o Operators.o Operator.o ProperCycle.o ProperPath.o CycleHelper.o ZOrderedCells.o EdgeSample.o Cycle.o Algorithms.o SmartKeyEdgeSet.o Triangles.o SelectionInfoWidget.o Path.o AnimatedVertex.o AnimatedCycle.o CellLinkedList.o HalfedgeBase.o KeyHalfedge.o ViewSettings.o View3DSettings.o ObjectPropertiesWidget.o AnimatedCycleWidget.o CellObserver.o Color.o DevSettings.o Settings.o SettingsDialog.o InbetweenCell.o InbetweenEdge.o InbetweenFace.o InbetweenHalfedge.o InbetweenVertex.o VAC.o XmlStreamWriter.o XmlStreamReader.o CssColor.o TimeDef.o EditCanvasSizeDialog.o ExportPngDialog.o AboutDialog.o ViewWidget.o Application.o Background.o BackgroundData.o BackgroundRenderer.o BackgroundWidget.o BackgroundUrlValidator.o FileVersionConverter.o XmlStreamTraverser.o XmlStreamConverter.o XmlStreamConverter_1_0_to_1_6.o FileVersionConverterDialog.o UpdateCheckDialog.o Version.o UpdateCheck.o BoundingBox.o TransformTool.o LayersWidget.o Layer.o SvgParser.o SvgImportDialog.o SvgImportParams.o qrc_resources.o moc_MainWindow.o moc_GLWidget.o moc_SceneObject.o moc_Scene.o moc_MultiView.o moc_View.o moc_View3D.o moc_Timeline.o moc_Global.o moc_ColorSelector.o moc_SpinBox.o moc_SelectionInfoWidget.o moc_ViewSettings.o moc_View3DSettings.o moc_ObjectPropertiesWidget.o moc_AnimatedCycleWidget.o moc_DevSettings.o moc_SettingsDialog.o moc_VAC.o moc_EditCanvasSizeDialog.o moc_ExportPngDialog.o moc_AboutDialog.o moc_ViewWidget.o moc_Application.o moc_Background.o moc_BackgroundRenderer.o moc_BackgroundWidget.o moc_FileVersionConverterDialog.o moc_UpdateCheckDialog.o moc_UpdateCheck.o moc_TransformTool.o moc_LayersWidget.o moc_Layer.o moc_SvgImportDialog.o   -lGLU -L/home/simon/vpaint/src/vpaint-1.7/build/Gui/../Third/GLEW/ -lGLEW /usr/lib/libQt5OpenGL.so /usr/lib/libQt5Widgets.so /usr/lib/libQt5OpenGLExtensions.a /usr/lib/libQt5Gui.so /usr/lib/libQt5Network.so /usr/lib/libQt5Core.so -lGL -lpthread
```

... and sure enough this builds for me again, without error (and VPaint can be started in the resulting build).

Now I have no idea what that parameter was, or is, supposed to do, so I'll leave you the final judgement if it can just be removed like that (without fear of breaking someone else's build), but from the looks of it, I would guess it shouldn't pose a problem.

Let me know if this can be merged (or if you'd rather postpone the whole thing due to limited time).

Merci beaucoup et à bientôt!